### PR TITLE
Run lspci only when pci devices list defined

### DIFF
--- a/genericvm_tempest_plugin/tests/scenario/test_image.py
+++ b/genericvm_tempest_plugin/tests/scenario/test_image.py
@@ -177,16 +177,17 @@ class GenericvmTestScenario(manager.ScenarioTest):
             self.assertTrue(module in the_modules,
                             mod_assert_text.format(module, the_modules))
 
-        lspci_run = linux_client.exec_command("lspci -m")
-        found_pci_devices = []
-        for device in lspci_run.split('\n'):
-            try:
-                found_pci_devices.append(device.split('"')[1])
-            except IndexError:
-                pass
-        for dev_class in pci_devices:
-            self.assertIn(dev_class, found_pci_devices,
-                          message='Required PCI device is not available')
+        if len(pci_devices) > 0:
+            lspci_run = linux_client.exec_command("lspci -m")
+            found_pci_devices = []
+            for device in lspci_run.split('\n'):
+                try:
+                    found_pci_devices.append(device.split('"')[1])
+                except IndexError:
+                    pass
+            for dev_class in pci_devices:
+                self.assertIn(dev_class, found_pci_devices,
+                            message='Required PCI device is not available')
 
         if check_nv_sni:
             # Rises exception if the exit code is not 0. When no vide card.

--- a/genericvm_tempest_plugin/tests/scenario/test_image.py
+++ b/genericvm_tempest_plugin/tests/scenario/test_image.py
@@ -187,7 +187,7 @@ class GenericvmTestScenario(manager.ScenarioTest):
                     pass
             for dev_class in pci_devices:
                 self.assertIn(dev_class, found_pci_devices,
-                            message='Required PCI device is not available')
+                              message='Required PCI device is not available')
 
         if check_nv_sni:
             # Rises exception if the exit code is not 0. When no vide card.


### PR DESCRIPTION
There is no need to run lspci if we do not expect to check any pci device available on a vm. In some cases lspci might not be installed or needed on the virtual machine.