### PR TITLE
Measure root fs size instead of sda1 drive

### DIFF
--- a/genericvm_tempest_plugin/tests/scenario/test_image.py
+++ b/genericvm_tempest_plugin/tests/scenario/test_image.py
@@ -166,7 +166,7 @@ class GenericvmTestScenario(manager.ScenarioTest):
                 "test -f /etc/cloud/getpass.sh && echo 1")
             self.assertEqual(1, int(getpass_present), msg)
         filesystem_size = linux_client.exec_command(
-            "df | grep '/dev/sda1' | awk '{ print $2 }'")
+            "df / | awk '{ print $2 }' | tail -n1")
         self.assertTrue(CONF.genericvm.fs_size < int(filesystem_size))
 
         lsof_run = linux_client.exec_command("lsmod")


### PR DESCRIPTION
Initially an sda1 mount was hardcoded into test, but better way is to look at / fs size. This way it will work on both sda or vda images.